### PR TITLE
amended Coerce-Rhino-object function. …

### DIFF
--- a/scripts/rhinoscript/utility.py
+++ b/scripts/rhinoscript/utility.py
@@ -463,6 +463,7 @@ def coerceguid(id, raise_exception=False):
     if (type(id) is list or type(id) is tuple) and len(id)==1:
         return coerceguid(id[0], raise_exception)
     if type(id) is Rhino.DocObjects.ObjRef: return id.ObjectId
+    if isinstance(id,Rhino.DocObjects.RhinoObject): return id.Id
     if raise_exception: raise TypeError("Parameter must be a Guid or string representing a Guid")
 
 
@@ -568,6 +569,7 @@ def coercemesh(object_id, raise_if_missing=False):
 
 def coercerhinoobject(object_id, raise_if_bad_input=False, raise_if_missing=False):
     "attempt to get RhinoObject from the document with a given id"
+    if isinstance(id,Rhino.DocObjects.RhinoObject): return object_id
     object_id = coerceguid(object_id, raise_if_bad_input)
     if object_id is None: return None
     rc = scriptcontext.doc.Objects.Find(object_id)


### PR DESCRIPTION
Hi Steve,
Since I am working with Rhinocommon and Rhinoscriptsyntax at the same time i sometimes have mixed lists of Guids and rhino objects.
I amended the 2 coerce functions to work for this case.
Does this make sense?

Is it in general better to work with lists of System.Guid or lists of Rhino.DocObjects.RhinoObject ?
I'll post this question to the forum...
