### PR TITLE
AddAlignedDimension handles the optional "style" parameter

### DIFF
--- a/scripts/rhinoscript/dimension.py
+++ b/scripts/rhinoscript/dimension.py
@@ -30,6 +30,10 @@ def AddAlignedDimension(start_point, end_point, point_on_dimension_line, style=N
     ldim = Rhino.Geometry.LinearDimension(plane, start, end, onpoint)
     if not ldim: return scriptcontext.errorhandler()
     ldim.Aligned = True
+    if style:
+        ds = scriptcontext.doc.DimStyles.Find(style, True)
+        if ds is None: return scriptcontext.errorhandler()
+        ldim.DimensionStyleIndex = ds.Index
     rc = scriptcontext.doc.Objects.AddLinearDimension(ldim)
     if rc==System.Guid.Empty: raise Exception("unable to add dimension to document")
     scriptcontext.doc.Views.Redraw()


### PR DESCRIPTION
The optional "style" parameter in AddAlignedDimension was ignored. I took the logic from CurrentDimStyle to find the index by name.
