### PR TITLE
ObjectLayer() returns now Layer.FullPath instead of Layer.Name. 

### DIFF
--- a/scripts/rhinoscript/object.py
+++ b/scripts/rhinoscript/object.py
@@ -522,7 +522,7 @@ def ObjectLayer(object_id, layer=None):
     obj = rhutil.coercerhinoobject(object_id, True, True)
     if obj is None: return scriptcontext.errorhandler()
     index = obj.Attributes.LayerIndex
-    rc = scriptcontext.doc.Layers[index].Name
+    rc = scriptcontext.doc.Layers[index].FullPath
     if layer:
         layer = __getlayer(layer, True)
         index = layer.LayerIndex


### PR DESCRIPTION
This change makes ObjectLayer() compatible with other layer functions. I suggest to extend this behavior to all rhinoscript layer functions. They should only work with the full path (inputs and returns).
