### PR TITLE
Changed LayerVisible(), to use layer.SetPersistentVisibility(False).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.project
+*.pydevproject

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-*.project
-*.pydevproject

--- a/scripts/rhinoscript/layer.py
+++ b/scripts/rhinoscript/layer.py
@@ -263,6 +263,7 @@ def LayerLocked(layer, locked=None):
     layer = __getlayer(layer, True)
     rc = layer.IsLocked
     if locked!=None and locked!=rc:
+        layer.SetPersistentLocking(True)
         layer.IsLocked = locked
         layer.CommitChanges()
         scriptcontext.doc.Views.Redraw()

--- a/scripts/rhinoscript/layer.py
+++ b/scripts/rhinoscript/layer.py
@@ -378,6 +378,7 @@ def LayerVisible(layer, visible=None, force_visible=False):
         if visible and force_visible:
             scriptcontext.doc.Layers.ForceLayerVisible(layer.Id)
         else:
+            layer.SetPersistentVisibility(False)
             layer.IsVisible = visible
             layer.CommitChanges()
         scriptcontext.doc.Views.Redraw()


### PR DESCRIPTION
Without this line layers that have been switched off with LayerVisible(l,
visible=False), behave strangely when they have parent layers. If the
parent layer is switched on and the child layer is switched off via the
function, it will not be fully off as in pushing the light bulb in the
layer editor UI. The child layer is in the state that it would have, when the parent
layer would be switched of (the half light bulb). This behavior is in
contrast to the behavior achieved with the UI. Furthermore, when a child
layer is in this weird hidden state and any layer is switched to locked
with the button in the layer manager, the hidden child layer switches back
on.
