### PR TITLE
AddAlignedDimension handles the optional "style" parameter

### DIFF
--- a/Scripts/rhinoscript/dimension.py
+++ b/Scripts/rhinoscript/dimension.py
@@ -38,6 +38,10 @@ def AddAlignedDimension(start_point, end_point, point_on_dimension_line, style=N
     ldim = Rhino.Geometry.LinearDimension(plane, start, end, onpoint)
     if not ldim: return scriptcontext.errorhandler()
     ldim.Aligned = True
+    if style:
+        ds = scriptcontext.doc.DimStyles.Find(style, True)
+        if ds is None: return scriptcontext.errorhandler()
+        ldim.DimensionStyleIndex = ds.Index
     rc = scriptcontext.doc.Objects.AddLinearDimension(ldim)
     if rc==System.Guid.Empty: raise Exception("unable to add dimension to document")
     scriptcontext.doc.Views.Redraw()


### PR DESCRIPTION
The changes in this pull request have been rebased onto `rhino-6.x`.

Description from the original pull request (#135):
>The optional "style" parameter in AddAlignedDimension was ignored. I took the logic from CurrentDimStyle to find the index by name.