### PR TITLE
Typos in sample code

### DIFF
--- a/Scripts/rhinoscript/mesh.py
+++ b/Scripts/rhinoscript/mesh.py
@@ -582,7 +582,7 @@ def MeshClosestPoint(object_id, point, maximum_distance=None):
                             [1] = the index of the mesh face on which the 3-D point lies
       None: on error
     Example:
-      import rhinocriptsyntax as rs
+      import rhinoscriptsyntax as rs
       obj = rs.GetObject("Select mesh", rs.filter.mesh)
       point = rs.GetPoint("Pick test point")
       intersect = rs.MeshClosestPoint(obj, point)

--- a/Scripts/rhinoscript/view.py
+++ b/Scripts/rhinoscript/view.py
@@ -1558,7 +1558,7 @@ def ZoomSelected(view=None, all=False):
     Returns:
       None
     Example:
-      import rhinocriptsyntax as rs
+      import rhinoscriptsyntax as rs
       obj = rs.GetObject("Select object", select=True)
       if obj: rs.ZoomSelected()
     See Also:


### PR DESCRIPTION
Hello, I spotted a missing s in rhinoscriptsytax in two of the files - I cannot see any more