### PR TITLE
Fix bug in rs.ObjectLayout

### DIFF
--- a/Scripts/rhinoscript/object.py
+++ b/Scripts/rhinoscript/object.py
@@ -920,7 +920,7 @@ def ObjectLayer(object_id, layer=None):
     return rc
 
 
-def ObjectLayout(object_id, layout=None, return_name=True):
+def ObjectLayout(object_id, layout="", return_name=True):
     """Returns or changes the layout or model space of an object
     Parameters:
       object_id (guid): identifier of the object


### PR DESCRIPTION
the optional argument should be falsey for line 959 but not `None`.
`None` is used as a valid argument to move objects to model space.